### PR TITLE
fix azure functionApp deployment slot name

### DIFF
--- a/.github/workflows/build_PR.yml
+++ b/.github/workflows/build_PR.yml
@@ -41,7 +41,8 @@ jobs:
     steps:
       - id: run
         run: |
-          echo "::set-output name=safeBranch::${HEAD_REF//_/-}"
+          DATA=${HEAD_REF##*/}
+          echo "::set-output name=safeBranch::`echo $DATA | sed -E 's/[^a-zA-Z0-9\-]/\-/g'`"
           echo "::set-output name=stag::${STAG::7}"
   Create_Slot:
     name: Create Azure functions slot if PR opened

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -24,8 +24,8 @@ jobs:
     name: Prepare environment variable
     runs-on: ubuntu-latest
     outputs:
-      BRANCH: ${{steps.run.outputs.branch}}
-      TAG_NAME: ${{steps.run.outputs.branch}}-${{steps.run.outputs.stag}}
+      BRANCH: ${{steps.run.outputs.safeBranch}}
+      TAG_NAME: ${{steps.run.outputs.safeBranch}}-${{steps.run.outputs.stag}}
     env:
       REF: ${{github.ref}}
       STAG: ${{github.sha}}
@@ -33,7 +33,7 @@ jobs:
       - id: run
         run: |
           DATA=${REF##*/}
-          echo "::set-output name=branch::${DATA//_/-}"
+          echo "::set-output name=safeBranch::`echo $DATA | sed -E 's/[^a-zA-Z0-9\-]/\-/g'`"
           echo "::set-output name=stag::${STAG::7}"
   Check:
     name: Check this commit is merged commit

--- a/.github/workflows/deleteSlot_PR_Closed.yml
+++ b/.github/workflows/deleteSlot_PR_Closed.yml
@@ -28,7 +28,8 @@ jobs:
     steps:
       - id: run
         run: |
-          echo "::set-output name=safeBranch::${HEAD_REF//_/-}"
+          DATA=${HEAD_REF##*/}
+          echo "::set-output name=safeBranch::`echo $DATA | sed -E 's/[^a-zA-Z0-9\-]/\-/g'`"
   DeleteSlot:
     name: Delte slot
     runs-on: ubuntu-latest


### PR DESCRIPTION
ブランチが/区切りで深くなっていたり、スロット名に使えない文字が入っているときにエラーになる。
Renovateを使うとブランチが深く区切られるため、表面化した。